### PR TITLE
Added Codecov.io coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,5 @@ before_install:
   # manually set sdk.dir variable, according to local paths
   - echo "sdk.dir=$ANDROID_HOME" > local.properties
   - echo yes | android update sdk -a -t tools,platform-tools,extra-android-support,extra-android-m2repository,android-19,build-tools-19.0.3 --force --no-ui
+  - sudo pip install codecov
+after_success: codecov

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PhotoView
 
-Branch **Dev**: [![Build Status](https://travis-ci.org/chrisbanes/PhotoView.png?branch=dev)](https://travis-ci.org/chrisbanes/PhotoView)  
-Branch **Master**: [![Build Status](https://travis-ci.org/chrisbanes/PhotoView.png?branch=master)](https://travis-ci.org/chrisbanes/PhotoView)
+Branch **Dev**: [![Build Status](https://travis-ci.org/chrisbanes/PhotoView.png?branch=dev)](https://travis-ci.org/chrisbanes/PhotoView) [![codecov.io](https://codecov.io/github/chrisbanes/PhotoView/coverage.svg?branch=dev)](https://codecov.io/github/chrisbanes/PhotoView?branch=dev)
+Branch **Master**: [![Build Status](https://travis-ci.org/chrisbanes/PhotoView.png?branch=master)](https://travis-ci.org/chrisbanes/PhotoView) [![codecov.io](https://codecov.io/github/chrisbanes/PhotoView/coverage.svg?branch=master)](https://codecov.io/github/chrisbanes/PhotoView?branch=master)
 
 ![PhotoView](https://raw.github.com/chrisbanes/PhotoView/master/header_graphic.png)
 

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,25 @@
 					</configuration>
 					<extensions>true</extensions>
 				</plugin>
+				<plugin>
+				    <groupId>org.jacoco</groupId>
+				    <artifactId>jacoco-maven-plugin</artifactId>
+				    <version>0.5.8.201207111220</version>
+				    <executions>
+				        <execution>
+				            <goals>
+				                <goal>prepare-agent</goal>
+				            </goals>
+				        </execution>
+				        <execution>
+				            <id>report</id>
+				            <phase>test</phase>
+				            <goals>
+				                <goal>report</goal>
+				            </goals>
+				        </execution>
+				    </executions>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
Hey Friends! I'm from [Codecov.io](https://codecov.io/) and I wanted to personally add our free coverage reporting tools to PhotoView.

When travis-ci passes you can see the live reports here: [codecov.io/github/chrisbanes/PhotoView](https://codecov.io/github/chrisbanes/PhotoView?ref=f4416ea7c208b56423a9680196b3d62cecb90d5b)

[![codecov.io](https://codecov.io/github/chrisbanes/PhotoView/coverage.svg?branch=master)](https://codecov.io/github/chrisbanes/PhotoView?branch=master)

Make sure to [signup](https://codecov.io/login/github) to enable these free [features](https://codecov.io/#features)

I'm excited to hear your feedback!
Thank you for your time.