### PR TITLE
Fix for regression on issue #72.

### DIFF
--- a/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
+++ b/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
@@ -68,6 +68,7 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
     private float mMaxScale = DEFAULT_MAX_SCALE;
 
     private boolean mAllowParentInterceptOnEdge = true;
+    private boolean mBlockParentIntercept = false;
 
     private static void checkZoomLevels(float minZoom, float midZoom,
                                         float maxZoom) {
@@ -369,7 +370,7 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
          * the edge, aka 'overscrolling', let the parent take over).
          */
         ViewParent parent = imageView.getParent();
-        if (mAllowParentInterceptOnEdge && !mScaleDragDetector.isScaling()) {
+        if (mAllowParentInterceptOnEdge && !mScaleDragDetector.isScaling() && !mBlockParentIntercept) {
             if (mScrollEdge == EDGE_BOTH
                     || (mScrollEdge == EDGE_LEFT && dx >= 1f)
                     || (mScrollEdge == EDGE_RIGHT && dx <= -1f)) {
@@ -485,15 +486,23 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
             }
 
             // Try the Scale/Drag detector
-            if (null != mScaleDragDetector
-                    && mScaleDragDetector.onTouchEvent(ev)) {
-                handled = true;
+            if (null != mScaleDragDetector) {
+                boolean wasScaling = mScaleDragDetector.isScaling();
+                boolean wasDragging = mScaleDragDetector.isDragging();
+
+                handled = mScaleDragDetector.onTouchEvent(ev);
+
+                boolean didntScale = !wasScaling && !mScaleDragDetector.isScaling();
+                boolean didntDrag = !wasDragging && !mScaleDragDetector.isDragging();
+
+                mBlockParentIntercept = didntScale && didntDrag;
             }
 
             // Check to see if the user double tapped
             if (null != mGestureDetector && mGestureDetector.onTouchEvent(ev)) {
                 handled = true;
             }
+
         }
 
         return handled;

--- a/library/src/main/java/uk/co/senab/photoview/gestures/CupcakeGestureDetector.java
+++ b/library/src/main/java/uk/co/senab/photoview/gestures/CupcakeGestureDetector.java
@@ -58,6 +58,10 @@ public class CupcakeGestureDetector implements GestureDetector {
         return false;
     }
 
+    public boolean isDragging() {
+        return mIsDragging;
+    }
+
     @Override
     public boolean onTouchEvent(MotionEvent ev) {
         switch (ev.getAction()) {

--- a/library/src/main/java/uk/co/senab/photoview/gestures/GestureDetector.java
+++ b/library/src/main/java/uk/co/senab/photoview/gestures/GestureDetector.java
@@ -23,6 +23,8 @@ public interface GestureDetector {
 
     public boolean isScaling();
 
+    public boolean isDragging();
+
     public void setOnGestureListener(OnGestureListener listener);
 
 }


### PR DESCRIPTION
If the PhotoView gesture detector handles scaling or dragging the PhotoView, we will continue to block the parent view from receiving onTouch events. If the gesture detector did not scale or drag the PhotoView at all, we allow the parent to properly receive all touch events.

Tested on 4.x and 5.x in an Activity with both a NavigationDrawer and a ViewPager. Both components work as designed along with scaling/panning a PhotoView.