### PR TITLE
Fix for regression on issue #72.

### DIFF
--- a/library/src/main/java/uk/co/senab/photoview/gestures/CupcakeGestureDetector.java
+++ b/library/src/main/java/uk/co/senab/photoview/gestures/CupcakeGestureDetector.java
@@ -58,6 +58,10 @@ public class CupcakeGestureDetector implements GestureDetector {
         return false;
     }
 
+    public boolean isDragging() {
+        return mIsDragging;
+    }
+
     @Override
     public boolean onTouchEvent(MotionEvent ev) {
         switch (ev.getAction()) {

--- a/library/src/main/java/uk/co/senab/photoview/gestures/GestureDetector.java
+++ b/library/src/main/java/uk/co/senab/photoview/gestures/GestureDetector.java
@@ -23,6 +23,8 @@ public interface GestureDetector {
 
     public boolean isScaling();
 
+    public boolean isDragging();
+
     public void setOnGestureListener(OnGestureListener listener);
 
 }


### PR DESCRIPTION
If the PhotoView gesture detector handles scaling or dragging the PhotoView, we will continue to block the parent view from receiving onTouch events. If the gesture detector did not scale or drag the PhotoView at all, we allow the parent to properly receive all touch events.

Tested on 4.x and 5.x in an Activity with both a NavigationDrawer and a ViewPager. Both components work as designed along with scaling/panning a PhotoView.