### PR TITLE
Add ability to unbind the image from the view so it can be panned freely.

### DIFF
--- a/library/src/main/java/uk/co/senab/photoview/IPhotoView.java
+++ b/library/src/main/java/uk/co/senab/photoview/IPhotoView.java
@@ -292,12 +292,20 @@ public interface IPhotoView {
     void setScaleType(ImageView.ScaleType scaleType);
 
     /**
-     * Allows you to enable/disable the zoom functionality on the ImageView. When disable the
+     * Allows you to enable/disable the zoom functionality on the ImageView. When disabled the
      * ImageView reverts to using the FIT_CENTER matrix.
      *
      * @param zoomable - Whether the zoom functionality is enabled.
      */
     void setZoomable(boolean zoomable);
+
+    /**
+     * Allows you to enable/disable jailing the image inside the view's bounds.  When disabled the
+     * image can be panned beyond the ImageView's bounds.
+     *
+     * @param bounded - Whether the image is bounded within the view.
+     */
+    void setBounded(boolean bounded);
 
     /**
      * Enables rotation via PhotoView internal functions. Name is chosen so it won't collide with

--- a/library/src/main/java/uk/co/senab/photoview/PhotoView.java
+++ b/library/src/main/java/uk/co/senab/photoview/PhotoView.java
@@ -269,6 +269,11 @@ public class PhotoView extends ImageView implements IPhotoView {
     }
 
     @Override
+    public void setBounded(boolean bounded) {
+        mAttacher.setBounded(bounded);
+    }
+
+    @Override
     public Bitmap getVisibleRectangleBitmap() {
         return mAttacher.getVisibleRectangleBitmap();
     }

--- a/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
+++ b/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
@@ -145,7 +145,7 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
     private FlingRunnable mCurrentFlingRunnable;
     private int mScrollEdge = EDGE_BOTH;
 
-    private boolean mZoomEnabled;
+    private boolean mZoomEnabled, mBoundsEnabled = true;
     private ScaleType mScaleType = ScaleType.FIT_CENTER;
 
     public PhotoViewAttacher(ImageView imageView) {
@@ -661,6 +661,11 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
         update();
     }
 
+    @Override
+    public void setBounded(boolean bounded) {
+        mBoundsEnabled = bounded;
+    }
+
     public void update() {
         ImageView imageView = getImageView();
 
@@ -778,7 +783,9 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
         }
 
         // Finally actually translate the matrix
-        mSuppMatrix.postTranslate(deltaX, deltaY);
+        if (mBoundsEnabled)
+            mSuppMatrix.postTranslate(deltaX, deltaY);
+
         return true;
     }
 


### PR DESCRIPTION
It is currently impossible to pan an image such that one of its edges is inside the view's bounds - the image is effectively jailed such that its edges will always be outside of the view's bounds.

For some use cases, it's useful to be able to freely pan an image around inside the view's bounds.  My particular case was images that act as stamps/badges on top of another image.  I scale the stamp down and allow the user to freely position it anywhere on the background.