### PR TITLE
Fix for Javadoc-error in PhotoViewAttacher.OnScaleChangeListener#onScaleChange

### DIFF
--- a/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
+++ b/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
@@ -962,7 +962,7 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
         /**
          * Callback for when the scale changes
          *
-         * @param scaleFactor the scale factor (<1 for zoom out, >1 for zoom in)
+         * @param scaleFactor the scale factor (&lt;1 for zoom out, &gt;1 for zoom in)
          * @param focusX      focal point X position
          * @param focusY      focal point Y position
          */


### PR DESCRIPTION
This error broke the gradle-task installArchives for me with the following error-message:

C:\Developer\workspace\PhotoView\library\src\main\java\uk\co\senab\photoview\PhotoViewAttacher.java:965: error: malformed HTML
         * @param scaleFactor the scale factor (<1 for zoom out, >1 for zoom in)
                                                ^
C:\Developer\workspace\PhotoView\library\src\main\java\uk\co\senab\photoview\PhotoViewAttacher.java:965: error: bad use of '>'
         * @param scaleFactor the scale factor (<1 for zoom out, >1 for zoom in)
                                                                 ^
2 errors
10 warnings
:library:androidJavadocs FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':library:androidJavadocs'.
> Javadoc generation failed. Generated Javadoc options file (useful for troubleshooting): 'C:\Developer\workspace\PhotoView\library\build\tmp\androidJavadocs\javadoc.options'