### PR TITLE
Corrected gradle uri in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Minimum code for Gradle integration, place code in your `build.gradle`
 
 ```gradle
 dependencies {
-  compile 'com.commit451:PhotoView:1.2.4'
+  compile 'com.github.chrisbanes.photoview:library:+'
 }
 ```
 


### PR DESCRIPTION
The gradle uri supplied in the documentation leads to a failed build.