### PR TITLE
Added void getDisplayMatrix(matrix) and corrected getDisplayMatrix documentation 

### DIFF
--- a/library/src/main/java/uk/co/senab/photoview/IPhotoView.java
+++ b/library/src/main/java/uk/co/senab/photoview/IPhotoView.java
@@ -58,9 +58,17 @@ public interface IPhotoView {
      * Gets the Display Matrix of the currently displayed Drawable. The Rectangle is considered
      * relative to this View and includes all scaling and translations.
      *
-     * @return - true if rectangle was applied successfully
+     * @return copy of current Display Matrix
      */
     Matrix getDisplayMatrix();
+
+    /**
+     * Copies the Display Matrix of the currently displayed Drawable. The Rectangle is considered
+     * relative to this View and includes all scaling and translations.
+     *
+     * @param matrix target matrix to copy to
+     */
+    void getDisplayMatrix(Matrix matrix);
 
     /**
      * Use {@link #getMinimumScale()} instead, this will be removed in future release

--- a/library/src/main/java/uk/co/senab/photoview/PhotoView.java
+++ b/library/src/main/java/uk/co/senab/photoview/PhotoView.java
@@ -94,6 +94,11 @@ public class PhotoView extends ImageView implements IPhotoView {
     }
 
     @Override
+    public void getDisplayMatrix(Matrix matrix) {
+        mAttacher.getDisplayMatrix(matrix);
+    }
+
+    @Override
     public boolean setDisplayMatrix(Matrix finalRectangle) {
         return mAttacher.setDisplayMatrix(finalRectangle);
     }

--- a/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
+++ b/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
@@ -683,6 +683,11 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
         return new Matrix(getDrawMatrix());
     }
 
+    @Override
+    public void getDisplayMatrix(Matrix matrix) {
+        matrix.set(getDisplayMatrix());
+    }
+
     public Matrix getDrawMatrix() {
         mDrawMatrix.set(mBaseMatrix);
         mDrawMatrix.postConcat(mSuppMatrix);

--- a/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
+++ b/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
@@ -685,7 +685,7 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
 
     @Override
     public void getDisplayMatrix(Matrix matrix) {
-        matrix.set(getDisplayMatrix());
+        matrix.set(getDrawMatrix());
     }
 
     public Matrix getDrawMatrix() {


### PR DESCRIPTION
- Updated documentation in IPhotoView to resolve invalid return value comment
- Added getDisplayMatrix(matrix) to IPhotoView to permit copy without allocation
- Implemented getDisplayMatrix(matrix) in PhotoViewAttacher
- Implemented getDisplayMatrix(matrix) proxy method in PhotoView