### PR TITLE
Deprecate getOnPhotoTapListener and getOnViewTapListener and update support library dependencies

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -14,7 +14,7 @@ android {
 }
 
 dependencies {
-    compile "com.android.support:support-v4:23.2.1"
+    compile "com.android.support:support-v4:23.3.0"
 }
 
 //./gradlew clean build bintrayUpload -PbintrayUser=BINTRAY_USERNAME -PbintrayKey=BINTRAY_KEY -PdryRun=false

--- a/library/src/main/java/uk/co/senab/photoview/IPhotoView.java
+++ b/library/src/main/java/uk/co/senab/photoview/IPhotoView.java
@@ -25,10 +25,10 @@ import android.widget.ImageView;
 
 public interface IPhotoView {
 
-    public static final float DEFAULT_MAX_SCALE = 3.0f;
-    public static final float DEFAULT_MID_SCALE = 1.75f;
-    public static final float DEFAULT_MIN_SCALE = 1.0f;
-    public static final int DEFAULT_ZOOM_DURATION = 200;
+    float DEFAULT_MAX_SCALE = 3.0f;
+    float DEFAULT_MID_SCALE = 1.75f;
+    float DEFAULT_MIN_SCALE = 1.0f;
+    int DEFAULT_ZOOM_DURATION = 200;
 
     /**
      * Returns true if the PhotoView is set to allow zooming of Photos.

--- a/library/src/main/java/uk/co/senab/photoview/IPhotoView.java
+++ b/library/src/main/java/uk/co/senab/photoview/IPhotoView.java
@@ -230,11 +230,15 @@ public interface IPhotoView {
     void setOnPhotoTapListener(PhotoViewAttacher.OnPhotoTapListener listener);
 
     /**
+     * PhotoViewAttacher.OnPhotoTapListener reference should be stored in a variable instead, this
+     * will be removed in future release.
+     * <p>&nbsp;</p>
      * Returns a listener to be invoked when the Photo displayed by this View is tapped with a
      * single tap.
      *
      * @return PhotoViewAttacher.OnPhotoTapListener currently set, may be null
      */
+    @Deprecated
     PhotoViewAttacher.OnPhotoTapListener getOnPhotoTapListener();
 
     /**
@@ -259,10 +263,14 @@ public interface IPhotoView {
     void setRotationBy(float rotationDegree);
 
     /**
+     * PhotoViewAttacher.OnViewTapListener reference should be stored in a variable instead, this
+     * will be removed in future release.
+     * <p>&nbsp;</p>
      * Returns a callback listener to be invoked when the View is tapped with a single tap.
      *
      * @return PhotoViewAttacher.OnViewTapListener currently set, may be null
      */
+    @Deprecated
     PhotoViewAttacher.OnViewTapListener getOnViewTapListener();
 
     /**

--- a/library/src/main/java/uk/co/senab/photoview/IPhotoView.java
+++ b/library/src/main/java/uk/co/senab/photoview/IPhotoView.java
@@ -169,7 +169,7 @@ public interface IPhotoView {
     @Deprecated
     void setMidScale(float midScale);
 
-    /*
+    /**
      * Sets the medium scale level. What this value represents depends on the current {@link android.widget.ImageView.ScaleType}.
      *
      * @param mediumScale medium scale preset

--- a/library/src/main/java/uk/co/senab/photoview/PhotoView.java
+++ b/library/src/main/java/uk/co/senab/photoview/PhotoView.java
@@ -230,6 +230,7 @@ public class PhotoView extends ImageView implements IPhotoView {
     }
 
     @Override
+    @Deprecated
     public OnPhotoTapListener getOnPhotoTapListener() {
         return mAttacher.getOnPhotoTapListener();
     }
@@ -240,6 +241,7 @@ public class PhotoView extends ImageView implements IPhotoView {
     }
 
     @Override
+    @Deprecated
     public OnViewTapListener getOnViewTapListener() {
         return mAttacher.getOnViewTapListener();
     }

--- a/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
+++ b/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
@@ -625,6 +625,7 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
     }
 
     @Override
+    @Deprecated
     public OnPhotoTapListener getOnPhotoTapListener() {
         return mPhotoTapListener;
     }
@@ -635,6 +636,7 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
     }
 
     @Override
+    @Deprecated
     public OnViewTapListener getOnViewTapListener() {
         return mViewTapListener;
     }

--- a/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
+++ b/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
@@ -991,7 +991,7 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
      *
      * @author Chris Banes
      */
-    public static interface OnMatrixChangedListener {
+    public interface OnMatrixChangedListener {
         /**
          * Callback for when the Matrix displaying the Drawable has changed. This could be because
          * the View's bounds have changed, or the user has zoomed.
@@ -1006,7 +1006,7 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
      *
      * @author Marek Sebera
      */
-    public static interface OnScaleChangeListener {
+    public interface OnScaleChangeListener {
         /**
          * Callback for when the scale changes
          *
@@ -1023,7 +1023,7 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
      *
      * @author Chris Banes
      */
-    public static interface OnPhotoTapListener {
+    public interface OnPhotoTapListener {
 
         /**
          * A callback to receive where the user taps on a photo. You will only receive a callback if
@@ -1068,7 +1068,7 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
      *
      * @author tonyjs
      */
-    public static interface OnSingleFlingListener {
+    public interface OnSingleFlingListener {
 
         /**
          * A callback to receive where the user flings on a ImageView. You will receive a callback if

--- a/library/src/main/java/uk/co/senab/photoview/gestures/CupcakeGestureDetector.java
+++ b/library/src/main/java/uk/co/senab/photoview/gestures/CupcakeGestureDetector.java
@@ -54,10 +54,12 @@ public class CupcakeGestureDetector implements GestureDetector {
         return ev.getY();
     }
 
+    @Override
     public boolean isScaling() {
         return false;
     }
 
+    @Override
     public boolean isDragging() {
         return mIsDragging;
     }

--- a/library/src/main/java/uk/co/senab/photoview/gestures/GestureDetector.java
+++ b/library/src/main/java/uk/co/senab/photoview/gestures/GestureDetector.java
@@ -19,12 +19,12 @@ import android.view.MotionEvent;
 
 public interface GestureDetector {
 
-    public boolean onTouchEvent(MotionEvent ev);
+    boolean onTouchEvent(MotionEvent ev);
 
-    public boolean isScaling();
+    boolean isScaling();
 
-    public boolean isDragging();
+    boolean isDragging();
 
-    public void setOnGestureListener(OnGestureListener listener);
+    void setOnGestureListener(OnGestureListener listener);
 
 }

--- a/library/src/main/java/uk/co/senab/photoview/gestures/OnGestureListener.java
+++ b/library/src/main/java/uk/co/senab/photoview/gestures/OnGestureListener.java
@@ -17,11 +17,11 @@ package uk.co.senab.photoview.gestures;
 
 public interface OnGestureListener {
 
-    public void onDrag(float dx, float dy);
+    void onDrag(float dx, float dy);
 
-    public void onFling(float startX, float startY, float velocityX,
-                        float velocityY);
+    void onFling(float startX, float startY, float velocityX,
+                 float velocityY);
 
-    public void onScale(float scaleFactor, float focusX, float focusY);
+    void onScale(float scaleFactor, float focusX, float focusY);
 
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -18,7 +18,7 @@ android {
 
 dependencies {
     compile project(':library')
-    compile 'com.android.support:appcompat-v7:23.2.1'
-    compile 'com.android.support:recyclerview-v7:23.2.1'
+    compile 'com.android.support:appcompat-v7:23.3.0'
+    compile 'com.android.support:recyclerview-v7:23.3.0'
     compile 'com.squareup.picasso:picasso:2.5.2'
 }


### PR DESCRIPTION
Deprecate the getters for these listeners as discussed in [#338](https://github.com/chrisbanes/PhotoView/pull/338).