### PR TITLE
Make getOnViewTapListener() and getOnPhotoTapListener() package local

### DIFF
--- a/library/src/main/java/uk/co/senab/photoview/IPhotoView.java
+++ b/library/src/main/java/uk/co/senab/photoview/IPhotoView.java
@@ -159,17 +159,6 @@ public interface IPhotoView {
     void setOnPhotoTapListener(PhotoViewAttacher.OnPhotoTapListener listener);
 
     /**
-     * PhotoViewAttacher.OnPhotoTapListener reference should be stored in a variable instead, this
-     * will be removed in future release.
-     * <p>&nbsp;</p>
-     * Returns a listener to be invoked when the Photo displayed by this View is tapped with a
-     * single tap.
-     *
-     * @return PhotoViewAttacher.OnPhotoTapListener currently set, may be null
-     */
-    PhotoViewAttacher.OnPhotoTapListener getOnPhotoTapListener();
-
-    /**
      * Register a callback to be invoked when the View is tapped with a single tap.
      *
      * @param listener - Listener to be registered.
@@ -189,16 +178,6 @@ public interface IPhotoView {
      * @param rotationDegree - Degree to rotate PhotoView by, should be in range 0 to 360
      */
     void setRotationBy(float rotationDegree);
-
-    /**
-     * PhotoViewAttacher.OnViewTapListener reference should be stored in a variable instead, this
-     * will be removed in future release.
-     * <p>&nbsp;</p>
-     * Returns a callback listener to be invoked when the View is tapped with a single tap.
-     *
-     * @return PhotoViewAttacher.OnViewTapListener currently set, may be null
-     */
-    PhotoViewAttacher.OnViewTapListener getOnViewTapListener();
 
     /**
      * Changes the current scale to the specified value.

--- a/library/src/main/java/uk/co/senab/photoview/PhotoView.java
+++ b/library/src/main/java/uk/co/senab/photoview/PhotoView.java
@@ -189,18 +189,8 @@ public class PhotoView extends ImageView implements IPhotoView {
     }
 
     @Override
-    public OnPhotoTapListener getOnPhotoTapListener() {
-        return mAttacher.getOnPhotoTapListener();
-    }
-
-    @Override
     public void setOnViewTapListener(OnViewTapListener listener) {
         mAttacher.setOnViewTapListener(listener);
-    }
-
-    @Override
-    public OnViewTapListener getOnViewTapListener() {
-        return mAttacher.getOnViewTapListener();
     }
 
     @Override

--- a/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
+++ b/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
@@ -22,6 +22,7 @@ import android.graphics.Matrix;
 import android.graphics.Matrix.ScaleToFit;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
+import android.support.annotation.Nullable;
 import android.support.v4.view.MotionEventCompat;
 import android.util.Log;
 import android.view.GestureDetector;
@@ -592,8 +593,8 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
         mPhotoTapListener = listener;
     }
 
-    @Override
-    public OnPhotoTapListener getOnPhotoTapListener() {
+    @Nullable
+    OnPhotoTapListener getOnPhotoTapListener() {
         return mPhotoTapListener;
     }
 
@@ -602,8 +603,8 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
         mViewTapListener = listener;
     }
 
-    @Override
-    public OnViewTapListener getOnViewTapListener() {
+    @Nullable
+    OnViewTapListener getOnViewTapListener() {
         return mViewTapListener;
     }
 


### PR DESCRIPTION
I removed these two methods from the `IPhotoView` interface as obviously methods inherited from the interface have to be `public`. It also makes more sense to remove them from the interface as it shouldn't be possible to override them via `getIPhotoViewImplementation()`. Previously discussed [here](https://github.com/chrisbanes/PhotoView/issues/343).