### PR TITLE
Add ExtendedScaleType for portrait images

### DIFF
--- a/library/src/main/java/uk/co/senab/photoview/ExtendedScaleType.java
+++ b/library/src/main/java/uk/co/senab/photoview/ExtendedScaleType.java
@@ -1,0 +1,46 @@
+package uk.co.senab.photoview;
+
+import android.widget.ImageView;
+
+public enum ExtendedScaleType {
+    TOP_CENTER,
+    TOP_CENTER_CROP,
+    TOP_CENTER_INSIDE,
+    CENTER,
+    CENTER_CROP,
+    CENTER_INSIDE,
+    FIT_CENTER,
+    FIT_END,
+    FIT_START,
+    FIT_XY;
+
+    public ImageView.ScaleType toImageScaleType() {
+        switch (this) {
+            case TOP_CENTER: return ImageView.ScaleType.MATRIX;
+            case TOP_CENTER_CROP: return ImageView.ScaleType.MATRIX;
+            case TOP_CENTER_INSIDE: return ImageView.ScaleType.MATRIX;
+            case CENTER: return ImageView.ScaleType.CENTER;
+            case CENTER_CROP: return ImageView.ScaleType.CENTER_CROP;
+            case CENTER_INSIDE: return ImageView.ScaleType.CENTER_INSIDE;
+            case FIT_CENTER: return ImageView.ScaleType.FIT_CENTER;
+            case FIT_END: return ImageView.ScaleType.FIT_END;
+            case FIT_START: return ImageView.ScaleType.FIT_START;
+            case FIT_XY: return ImageView.ScaleType.FIT_XY;
+            default: return ImageView.ScaleType.MATRIX;
+        }
+    }
+
+    public static ExtendedScaleType fromImageScaleType(ImageView.ScaleType scaleType) {
+        switch (scaleType) {
+            case CENTER: return CENTER;
+            case CENTER_CROP: return CENTER_CROP;
+            case CENTER_INSIDE: return CENTER_INSIDE;
+            case FIT_CENTER: return FIT_CENTER;
+            case FIT_END: return FIT_END;
+            case FIT_START: return FIT_START;
+            case FIT_XY: return FIT_XY;
+            default: throw new IllegalArgumentException(scaleType.name()
+                    + " is not supported in PhotoView");
+        }
+    }
+}

--- a/library/src/main/java/uk/co/senab/photoview/IPhotoView.java
+++ b/library/src/main/java/uk/co/senab/photoview/IPhotoView.java
@@ -20,7 +20,6 @@ import android.graphics.Matrix;
 import android.graphics.RectF;
 import android.view.GestureDetector;
 import android.view.View;
-import android.widget.ImageView;
 
 
 public interface IPhotoView {
@@ -64,19 +63,19 @@ public interface IPhotoView {
 
     /**
      * @return The current minimum scale level. What this value represents depends on the current
-     * {@link android.widget.ImageView.ScaleType}.
+     * {@link ExtendedScaleType}.
      */
     float getMinimumScale();
 
     /**
      * @return The current medium scale level. What this value represents depends on the current
-     * {@link android.widget.ImageView.ScaleType}.
+     * {@link ExtendedScaleType}.
      */
     float getMediumScale();
 
     /**
      * @return The current maximum scale level. What this value represents depends on the current
-     * {@link android.widget.ImageView.ScaleType}.
+     * {@link ExtendedScaleType}.
      */
     float getMaximumScale();
 
@@ -90,9 +89,9 @@ public interface IPhotoView {
     /**
      * Return the current scale type in use by the ImageView.
      *
-     * @return current ImageView.ScaleType
+     * @return current ExtendedScaleType
      */
-    ImageView.ScaleType getScaleType();
+    ExtendedScaleType getExtendedScaleType();
 
     /**
      * Whether to allow the ImageView's parent to intercept the touch event when the photo is scroll
@@ -104,14 +103,15 @@ public interface IPhotoView {
 
     /**
      * Sets the minimum scale level. What this value represents depends on the current {@link
-     * android.widget.ImageView.ScaleType}.
+     * ExtendedScaleType}.
      *
      * @param minimumScale minimum allowed scale
      */
     void setMinimumScale(float minimumScale);
 
     /**
-     * Sets the medium scale level. What this value represents depends on the current {@link android.widget.ImageView.ScaleType}.
+     * Sets the medium scale level. What this value represents depends on the current {@link
+     * ExtendedScaleType}.
      *
      * @param mediumScale medium scale preset
      */
@@ -119,7 +119,7 @@ public interface IPhotoView {
 
     /**
      * Sets the maximum scale level. What this value represents depends on the current {@link
-     * android.widget.ImageView.ScaleType}.
+     * ExtendedScaleType}.
      *
      * @param maximumScale maximum allowed scale preset
      */
@@ -207,11 +207,11 @@ public interface IPhotoView {
     /**
      * Controls how the image should be resized or moved to match the size of the ImageView. Any
      * scaling or panning will happen within the confines of this {@link
-     * android.widget.ImageView.ScaleType}.
+     * ExtendedScaleType}.
      *
      * @param scaleType - The desired scaling mode.
      */
-    void setScaleType(ImageView.ScaleType scaleType);
+    void setExtendedScaleType(ExtendedScaleType scaleType);
 
     /**
      * Allows you to enable/disable the zoom functionality on the ImageView. When disable the

--- a/library/src/main/java/uk/co/senab/photoview/PhotoView.java
+++ b/library/src/main/java/uk/co/senab/photoview/PhotoView.java
@@ -33,7 +33,7 @@ public class PhotoView extends ImageView implements IPhotoView {
 
     private PhotoViewAttacher mAttacher;
 
-    private ScaleType mPendingScaleType;
+    private ExtendedScaleType mPendingScaleType;
 
     public PhotoView(Context context) {
         this(context, null);
@@ -55,7 +55,7 @@ public class PhotoView extends ImageView implements IPhotoView {
         }
 
         if (null != mPendingScaleType) {
-            setScaleType(mPendingScaleType);
+            setExtendedScaleType(mPendingScaleType);
             mPendingScaleType = null;
         }
     }
@@ -119,8 +119,13 @@ public class PhotoView extends ImageView implements IPhotoView {
     }
 
     @Override
+    public ExtendedScaleType getExtendedScaleType() {
+        return mAttacher.getExtendedScaleType();
+    }
+
+    @Override
     public ScaleType getScaleType() {
-        return mAttacher.getScaleType();
+        return getExtendedScaleType().toImageScaleType();
     }
 
     @Override
@@ -209,12 +214,17 @@ public class PhotoView extends ImageView implements IPhotoView {
     }
 
     @Override
-    public void setScaleType(ScaleType scaleType) {
+    public void setExtendedScaleType(ExtendedScaleType scaleType) {
         if (null != mAttacher) {
-            mAttacher.setScaleType(scaleType);
+            mAttacher.setExtendedScaleType(scaleType);
         } else {
             mPendingScaleType = scaleType;
         }
+    }
+
+    @Override
+    public void setScaleType(ScaleType scaleType) {
+        setExtendedScaleType(ExtendedScaleType.fromImageScaleType(scaleType));
     }
 
     @Override

--- a/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
+++ b/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
@@ -93,24 +93,6 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
     }
 
     /**
-     * @return true if the ScaleType is supported.
-     */
-    private static boolean isSupportedScaleType(final ScaleType scaleType) {
-        if (null == scaleType) {
-            return false;
-        }
-
-        switch (scaleType) {
-            case MATRIX:
-                throw new IllegalArgumentException(scaleType.name()
-                        + " is not supported in PhotoView");
-
-            default:
-                return true;
-        }
-    }
-
-    /**
      * Set's the ImageView's ScaleType to Matrix.
      */
     private static void setImageViewScaleTypeMatrix(ImageView imageView) {
@@ -152,7 +134,7 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
     private float mBaseRotation;
 
     private boolean mZoomEnabled;
-    private ScaleType mScaleType = ScaleType.FIT_CENTER;
+    private ExtendedScaleType mScaleType = ExtendedScaleType.FIT_CENTER;
 
     public PhotoViewAttacher(ImageView imageView) {
         this(imageView, true);
@@ -374,7 +356,7 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
     }
 
     @Override
-    public ScaleType getScaleType() {
+    public ExtendedScaleType getExtendedScaleType() {
         return mScaleType;
     }
 
@@ -659,8 +641,8 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
     }
 
     @Override
-    public void setScaleType(ScaleType scaleType) {
-        if (isSupportedScaleType(scaleType) && scaleType != mScaleType) {
+    public void setExtendedScaleType(ExtendedScaleType scaleType) {
+        if (null != scaleType && scaleType != mScaleType) {
             mScaleType = scaleType;
 
             // Finally update
@@ -904,17 +886,30 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
         final float widthScale = viewWidth / drawableWidth;
         final float heightScale = viewHeight / drawableHeight;
 
-        if (mScaleType == ScaleType.CENTER) {
+        if (mScaleType == ExtendedScaleType.TOP_CENTER) {
+            mBaseMatrix.postTranslate((viewWidth - drawableWidth) / 2F, 0);
+
+        } else if (mScaleType == ExtendedScaleType.TOP_CENTER_CROP) {
+            float scale = Math.max(widthScale, heightScale);
+            mBaseMatrix.postScale(scale, scale);
+            mBaseMatrix.postTranslate((viewWidth - drawableWidth * scale) / 2F, 0);
+
+        } else if (mScaleType == ExtendedScaleType.TOP_CENTER_INSIDE) {
+            float scale = Math.min(1.0f, widthScale);
+            mBaseMatrix.postScale(scale, scale);
+            mBaseMatrix.postTranslate((viewWidth - drawableWidth * scale) / 2F, 0);
+
+        } else if (mScaleType == ExtendedScaleType.CENTER) {
             mBaseMatrix.postTranslate((viewWidth - drawableWidth) / 2F,
                     (viewHeight - drawableHeight) / 2F);
 
-        } else if (mScaleType == ScaleType.CENTER_CROP) {
+        } else if (mScaleType == ExtendedScaleType.CENTER_CROP) {
             float scale = Math.max(widthScale, heightScale);
             mBaseMatrix.postScale(scale, scale);
             mBaseMatrix.postTranslate((viewWidth - drawableWidth * scale) / 2F,
                     (viewHeight - drawableHeight * scale) / 2F);
 
-        } else if (mScaleType == ScaleType.CENTER_INSIDE) {
+        } else if (mScaleType == ExtendedScaleType.CENTER_INSIDE) {
             float scale = Math.min(1.0f, Math.min(widthScale, heightScale));
             mBaseMatrix.postScale(scale, scale);
             mBaseMatrix.postTranslate((viewWidth - drawableWidth * scale) / 2F,

--- a/sample/src/main/java/uk/co/senab/photoview/sample/SimpleSampleActivity.java
+++ b/sample/src/main/java/uk/co/senab/photoview/sample/SimpleSampleActivity.java
@@ -31,7 +31,6 @@ import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.ImageView;
-import android.widget.ImageView.ScaleType;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -39,6 +38,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.util.Random;
 
+import uk.co.senab.photoview.ExtendedScaleType;
 import uk.co.senab.photoview.PhotoViewAttacher;
 import uk.co.senab.photoview.PhotoViewAttacher.OnMatrixChangedListener;
 import uk.co.senab.photoview.PhotoViewAttacher.OnPhotoTapListener;
@@ -107,32 +107,44 @@ public class SimpleSampleActivity extends AppCompatActivity {
                 mAttacher.setZoomable(!mAttacher.canZoom());
                 return true;
 
+            case R.id.menu_scale_top_center:
+                mAttacher.setExtendedScaleType(ExtendedScaleType.TOP_CENTER);
+                return true;
+
+            case R.id.menu_scale_top_center_crop:
+                mAttacher.setExtendedScaleType(ExtendedScaleType.TOP_CENTER_CROP);
+                return true;
+
+            case R.id.menu_scale_top_center_inside:
+                mAttacher.setExtendedScaleType(ExtendedScaleType.TOP_CENTER_INSIDE);
+                return true;
+
             case R.id.menu_scale_fit_center:
-                mAttacher.setScaleType(ScaleType.FIT_CENTER);
+                mAttacher.setExtendedScaleType(ExtendedScaleType.FIT_CENTER);
                 return true;
 
             case R.id.menu_scale_fit_start:
-                mAttacher.setScaleType(ScaleType.FIT_START);
+                mAttacher.setExtendedScaleType(ExtendedScaleType.FIT_START);
                 return true;
 
             case R.id.menu_scale_fit_end:
-                mAttacher.setScaleType(ScaleType.FIT_END);
+                mAttacher.setExtendedScaleType(ExtendedScaleType.FIT_END);
                 return true;
 
             case R.id.menu_scale_fit_xy:
-                mAttacher.setScaleType(ScaleType.FIT_XY);
+                mAttacher.setExtendedScaleType(ExtendedScaleType.FIT_XY);
                 return true;
 
             case R.id.menu_scale_scale_center:
-                mAttacher.setScaleType(ScaleType.CENTER);
+                mAttacher.setExtendedScaleType(ExtendedScaleType.CENTER);
                 return true;
 
             case R.id.menu_scale_scale_center_crop:
-                mAttacher.setScaleType(ScaleType.CENTER_CROP);
+                mAttacher.setExtendedScaleType(ExtendedScaleType.CENTER_CROP);
                 return true;
 
             case R.id.menu_scale_scale_center_inside:
-                mAttacher.setScaleType(ScaleType.CENTER_INSIDE);
+                mAttacher.setExtendedScaleType(ExtendedScaleType.CENTER_INSIDE);
                 return true;
 
             case R.id.menu_scale_random_animate:

--- a/sample/src/main/res/menu/main_menu.xml
+++ b/sample/src/main/res/menu/main_menu.xml
@@ -7,6 +7,15 @@
         android:id="@+id/menu_zoom_toggle"
         android:title="@string/menu_zoom_disable"/>
     <item
+        android:id="@+id/menu_scale_top_center"
+        android:title="@string/menu_scale_top_center"/>
+    <item
+        android:id="@+id/menu_scale_top_center_crop"
+        android:title="@string/menu_scale_top_center_crop"/>
+    <item
+        android:id="@+id/menu_scale_top_center_inside"
+        android:title="@string/menu_scale_top_center_inside"/>
+    <item
         android:id="@+id/menu_scale_fit_center"
         android:title="@string/menu_scale_fit_center"/>
     <item

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -3,6 +3,9 @@
     <string name="app_name">PhotoView Sample</string>
     <string name="menu_zoom_enable">Enable Zoom</string>
     <string name="menu_zoom_disable">Disable Zoom</string>
+    <string name="menu_scale_top_center">Change to TOP_CENTER</string>
+    <string name="menu_scale_top_center_crop">Change to TOP_CENTER_CROP</string>
+    <string name="menu_scale_top_center_inside">Change to TOP_CENTER_INSIDE</string>
     <string name="menu_scale_fit_center">Change to FIT_CENTER</string>
     <string name="menu_scale_fit_start">Change to FIT_START</string>
     <string name="menu_scale_fit_end">Change to FIT_END</string>


### PR DESCRIPTION
I decide to add new scale types required for portrait images (for documents photos).

This changes does not break back compatibility (users still can setup scale type through setScaleType() method). Those who need to use new scale types should use setExtendedScaleType() method instead.
