### PR TITLE
Fix post-Lollipop shared elements transition animations

### DIFF
--- a/library/src/main/java/uk/co/senab/photoview/PhotoView.java
+++ b/library/src/main/java/uk/co/senab/photoview/PhotoView.java
@@ -124,6 +124,11 @@ public class PhotoView extends ImageView implements IPhotoView {
     }
 
     @Override
+    public Matrix getImageMatrix() {
+        return mAttacher.getImageMatrix();
+    }
+
+    @Override
     public void setAllowParentInterceptOnEdge(boolean allow) {
         mAttacher.setAllowParentInterceptOnEdge(allow);
     }
@@ -168,6 +173,13 @@ public class PhotoView extends ImageView implements IPhotoView {
     @Override
     public void setImageURI(Uri uri) {
         super.setImageURI(uri);
+        if (null != mAttacher) {
+            mAttacher.update();
+        }
+    }
+
+    @Override
+    protected boolean setFrame(int l, int t, int r, int b) {
         if (null != mAttacher) {
             mAttacher.update();
         }

--- a/library/src/main/java/uk/co/senab/photoview/PhotoView.java
+++ b/library/src/main/java/uk/co/senab/photoview/PhotoView.java
@@ -180,9 +180,11 @@ public class PhotoView extends ImageView implements IPhotoView {
 
     @Override
     protected boolean setFrame(int l, int t, int r, int b) {
+        boolean changed = super.setFrame(l, t, r, b);
         if (null != mAttacher) {
             mAttacher.update();
         }
+        return changed;
     }
 
     @Override

--- a/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
+++ b/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
@@ -720,6 +720,10 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
         }
     }
 
+    public Matrix getImageMatrix() {
+        return mDrawMatrix;
+    }
+
     /**
      * Helper method that simply checks the Matrix, and then displays the result
      */


### PR DESCRIPTION
Fix this issue: https://github.com/chrisbanes/PhotoView/issues/243
The main problem was that PhotoView does not override getImageMatrix
method, and when ChangeImageTransform call image.getImageMatrix() it
will receive matrix not from PhotoViewAttacher, but from PhotoView's
parent ImageView.