### PR TITLE
Add callback onScaleEnd to OnScaleChangeListener

### DIFF
--- a/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
+++ b/library/src/main/java/uk/co/senab/photoview/PhotoViewAttacher.java
@@ -478,6 +478,13 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
         }
     }
 
+    @Override
+    public void onScaleEnd(float scaleFactor, float focusX, float focusY) {
+        if (null != mScaleChangeListener) {
+            mScaleChangeListener.onScaleEnd(scaleFactor, focusX, focusY);
+        }
+    }
+
     @SuppressLint("ClickableViewAccessibility")
     @Override
     public boolean onTouch(View v, MotionEvent ev) {
@@ -991,6 +998,15 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
          * @param focusY      focal point Y position
          */
         void onScaleChange(float scaleFactor, float focusX, float focusY);
+
+        /**
+         * Callback for when the scale gesture has ended
+         *
+         * @param scaleFactor the scale factor (<1 for zoom out, >1 for zoom in)
+         * @param focusX      focal point X position
+         * @param focusY      focal point Y position
+         */
+        void onScaleEnd(float scaleFactor, float focusX, float focusY);
     }
 
     /**

--- a/library/src/main/java/uk/co/senab/photoview/gestures/FroyoGestureDetector.java
+++ b/library/src/main/java/uk/co/senab/photoview/gestures/FroyoGestureDetector.java
@@ -48,7 +48,7 @@ public class FroyoGestureDetector extends EclairGestureDetector {
 
             @Override
             public void onScaleEnd(ScaleGestureDetector detector) {
-                // NO-OP
+                mListener.onScaleEnd(detector.getScaleFactor(), detector.getFocusX(), detector.getFocusY());
             }
         };
         mDetector = new ScaleGestureDetector(context, mScaleListener);

--- a/library/src/main/java/uk/co/senab/photoview/gestures/OnGestureListener.java
+++ b/library/src/main/java/uk/co/senab/photoview/gestures/OnGestureListener.java
@@ -24,4 +24,6 @@ public interface OnGestureListener {
 
     void onScale(float scaleFactor, float focusX, float focusY);
 
+    void onScaleEnd(float scaleFactor, float focusX, float focusY);
+
 }


### PR DESCRIPTION
I have added a callback `onScaleEnd` to `OnScaleChangeListener` which is called after users have completed their scale gesture. My implementation is forwarding the callback of the same name in Android's `ScaleGestureDetector.OnScaleGestureListener` all the way up to `PhotoViewAttacher`.

The use case is to show/hide additional UI controls after a new zoom scale has been set by the user's gesture.
