### PR TITLE
Possibility for parent to intercept touch events on vertical edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ allprojects {
 Then, add the library to your project `build.gradle`
 ```gradle
 dependencies {
-    compile 'com.github.chrisbanes:PhotoView:1.2.7'
+    compile 'com.github.chrisbanes:PhotoView:1.3.0'
 }
 ```
 

--- a/library/src/main/java/uk/co/senab/photoview/IPhotoView.java
+++ b/library/src/main/java/uk/co/senab/photoview/IPhotoView.java
@@ -100,7 +100,15 @@ public interface IPhotoView {
      *
      * @param allow whether to allow intercepting by parent element or not
      */
-    void setAllowParentInterceptOnEdge(boolean allow);
+    void setAllowParentInterceptOnHorizontalEdge(boolean allow);
+
+    /**
+     * Whether to allow the ImageView's parent to intercept the touch event when the photo is scroll
+     * to it's vertical edge.
+     *
+     * @param allow whether to allow intercepting by parent element or not
+     */
+    void setAllowParentInterceptOnVerticalEdge(boolean allow);
 
     /**
      * Sets the minimum scale level. What this value represents depends on the current {@link

--- a/library/src/main/java/uk/co/senab/photoview/PhotoView.java
+++ b/library/src/main/java/uk/co/senab/photoview/PhotoView.java
@@ -121,8 +121,12 @@ public class PhotoView extends ImageView implements IPhotoView {
     }
 
     @Override
-    public void setAllowParentInterceptOnEdge(boolean allow) {
-        mAttacher.setAllowParentInterceptOnEdge(allow);
+    public void setAllowParentInterceptOnHorizontalEdge(boolean allow) {
+        mAttacher.setAllowParentInterceptOnHorizontalEdge(allow);
+    }
+
+    @Override public void setAllowParentInterceptOnVerticalEdge(boolean allow) {
+        mAttacher.setAllowParentInterceptOnVerticalEdge(allow);
     }
 
     @Override


### PR DESCRIPTION
Implemented request for disallowing touch event intercepting when PV is scrolled to the top or bottom edge. Potential use cases: PhotoView in vertical ViewPager or inside CollapsingToolbarLayout.

Using bit masking to flag current edge. This allows for further customization of parent intercepting behaviour (e.g. intercept only on bottom edge) 
