### PR TITLE
Fix Simple Sample / Capture Display Matrix Crash

### DIFF
--- a/sample/src/main/java/uk/co/senab/photoview/sample/SimpleSampleActivity.java
+++ b/sample/src/main/java/uk/co/senab/photoview/sample/SimpleSampleActivity.java
@@ -154,6 +154,7 @@ public class SimpleSampleActivity extends AppCompatActivity {
                     mAttacher.setDisplayMatrix(mCurrentDisplayMatrix);
                 return true;
             case R.id.menu_matrix_capture:
+                mCurrentDisplayMatrix = new Matrix();
                 mAttacher.getDisplayMatrix(mCurrentDisplayMatrix);
                 return true;
             case R.id.extract_visible_bitmap:


### PR DESCRIPTION
I found `Simple Sample > Menu  > Capture Display Matrix ` to crash.
mCurrentDisplayMatrix was null.

And  I think that `Restore Display Matrix`  feature  works fine in below code . 
```
             case R.id.menu_matrix_capture:
-                mAttacher.getDisplayMatrix(mCurrentDisplayMatrix);
+                mAttacher.getSuppMatrix(mCurrentDisplayMatrix); // why getSuppMatrix works fine?
```
