### PR TITLE
Add OnViewTapListener which behaves same as the one in 1.x

### DIFF
--- a/photoview/src/main/java/com/github/chrisbanes/photoview/OnViewTapListener.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/OnViewTapListener.java
@@ -1,0 +1,16 @@
+package com.github.chrisbanes.photoview;
+
+import android.view.View;
+
+public interface OnViewTapListener {
+
+    /**
+     * A callback to receive where the user taps on a ImageView. You will receive a callback if
+     * the user taps anywhere on the view, tapping on 'whitespace' will not be ignored.
+     *
+     * @param view - View the user tapped.
+     * @param x    - where the user tapped from the left of the View.
+     * @param y    - where the user tapped from the top of the View.
+     */
+    void onViewTap(View view, float x, float y);
+}

--- a/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoView.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoView.java
@@ -204,6 +204,10 @@ public class PhotoView extends ImageView {
         attacher.setOnOutsidePhotoTapListener(listener);
     }
 
+    public void setOnViewTapListener(OnViewTapListener listener) {
+        attacher.setOnViewTapListener(listener);
+    }
+
     public void setScale(float scale) {
         attacher.setScale(scale);
     }

--- a/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
@@ -78,6 +78,7 @@ public class PhotoViewAttacher implements View.OnTouchListener,
     private OnMatrixChangedListener mMatrixChangeListener;
     private OnPhotoTapListener mPhotoTapListener;
     private OnOutsidePhotoTapListener mOutsidePhotoTapListener;
+    private OnViewTapListener mViewTapListener;
     private View.OnClickListener mOnClickListener;
     private OnLongClickListener mLongClickListener;
     private OnScaleChangedListener mScaleChangeListener;
@@ -430,6 +431,10 @@ public class PhotoViewAttacher implements View.OnTouchListener,
 
     public void setOnOutsidePhotoTapListener(OnOutsidePhotoTapListener mOutsidePhotoTapListener) {
         this.mOutsidePhotoTapListener = mOutsidePhotoTapListener;
+    }
+
+    public void setOnViewTapListener(OnViewTapListener listener) {
+        mViewTapListener = listener;
     }
 
     public void setScale(float scale) {

--- a/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
@@ -142,8 +142,13 @@ public class PhotoViewAttacher implements View.OnTouchListener,
                 }
                 final RectF displayRect = getDisplayRect();
 
+                final float x = e.getX(), y = e.getY();
+
+                if (mViewTapListener != null) {
+                    mViewTapListener.onViewTap(mImageView, x, y);
+                }
+
                 if (displayRect != null) {
-                    final float x = e.getX(), y = e.getY();
 
                     // Check to see if the user tapped on the photo
                     if (displayRect.contains(x, y)) {


### PR DESCRIPTION
I think some people needs `OnViewTapListener` even in v2.0.

For example, think about PhotoViews inside a ViewPager.
What if I want to implement a feature something like going previous/next page on tap left/right side?
Neither `OnPhotoTapListener` nor `OnOutsidePhotoTapListener` is enough.
(`OnOutsidePhotoTapListener` lacks x/y arguments to tell which side is actually tapped.)

So, I made a PR to implement `OnViewTapListener` which actually behaves the same as one in 1.x.
Would you please check it out?
Thanks.