### PR TITLE
Revert to old logic for layout change listener

### DIFF
--- a/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
@@ -320,8 +320,14 @@ public class PhotoViewAttacher implements View.OnTouchListener,
 
     @Override
     public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
-        // Update our base matrix, as the bounds have changed
-        updateBaseMatrix(mImageView.getDrawable());
+        if (mZoomEnabled) {
+            if (top != oldTop || bottom != oldBottom || left != oldLeft || right != oldRight) {
+                // Update our base matrix, as the bounds have changed
+                updateBaseMatrix(mImageView.getDrawable());
+            }
+        } else {
+            updateBaseMatrix(mImageView.getDrawable());
+        }
     }
 
     @Override


### PR DESCRIPTION
Revert back to old logic for layout change listener.
[old logic](https://github.com/chrisbanes/PhotoView/commit/1de1e50c7ae2a560abe8202f005a4765b32f39ba#diff-ba07f735ed51a279480298ac9e3d9b37L369)
It should fix https://github.com/chrisbanes/PhotoView/issues/452 and https://github.com/chrisbanes/PhotoView/issues/493.
Because when we are trying to set an initial scale by setScale, even if we are posting a runnable, onLayoutChange will be triggered after setScale. Inside onLayoutChange, updateBaseMatrix will reset the mSuppMatrix. Then setScale won't work for the initial setScale.