### PR TITLE
Fix maxscale

### DIFF
--- a/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoView.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoView.java
@@ -166,6 +166,14 @@ public class PhotoView extends ImageView {
         return attacher.setDisplayMatrix(finalRectangle);
     }
 
+    public void getSuppMatrix(Matrix matrix) {
+        attacher.getSuppMatrix(matrix);
+    }
+
+    public boolean setSuppMatrix(Matrix matrix) {
+        return attacher.setDisplayMatrix(matrix);
+    }
+
     public float getMinimumScale() {
         return attacher.getMinimumScale();
     }

--- a/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
@@ -851,7 +851,7 @@ public class PhotoViewAttacher implements View.OnTouchListener,
                 final int newY = mScroller.getCurrY();
 
                 mSuppMatrix.postTranslate(mCurrentX - newX, mCurrentY - newY);
-                setImageViewMatrix(getDrawMatrix());
+                checkAndDisplayMatrix();
 
                 mCurrentX = newX;
                 mCurrentY = newY;

--- a/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
@@ -371,6 +371,13 @@ public class PhotoViewAttacher implements View.OnTouchListener,
                                     rect.centerX(), rect.centerY()));
                             handled = true;
                         }
+                    } else if (getScale() > mMaxScale) {
+                        RectF rect = getDisplayRect();
+                        if (rect != null) {
+                            v.post(new AnimatedZoomRunnable(getScale(), mMaxScale,
+                                    rect.centerX(), rect.centerY()));
+                            handled = true;
+                        }
                     }
                     break;
             }

--- a/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
@@ -290,8 +290,7 @@ public class PhotoViewAttacher implements View.OnTouchListener,
         }
 
         mSuppMatrix.set(finalMatrix);
-        setImageViewMatrix(getDrawMatrix());
-        checkMatrixBounds();
+        checkAndDisplayMatrix();
 
         return true;
     }


### PR DESCRIPTION
First, revert back to old logic for layout change listener. [old logic](https://github.com/chrisbanes/PhotoView/commit/1de1e50c7ae2a560abe8202f005a4765b32f39ba#diff-ba07f735ed51a279480298ac9e3d9b37L369)
It should fix https://github.com/chrisbanes/PhotoView/issues/452 and https://github.com/chrisbanes/PhotoView/issues/493.
Because when we are trying to set an initial scale by setScale, even if we are posting a runnable, onLayoutChange will be triggered after setScale. Inside onLayoutChange, updateBaseMatrix will reset the mSuppMatrix. Then setScale won't work for the initial setScale.

Second, add public methods getSuppMatrix and setSuppMatrix to save and restore scale and visible area, which should fix https://github.com/chrisbanes/PhotoView/issues/509.

Third, sometimes the user can zoom the image larger than the max scale, which happens when we move the two fingers close first and then far away with a fling. We should make the image zoom back to the max scale.

Last, if we force the image to zoom back to max scale, with the above gesture, sometimes it causes the boundary issue. Please see the gif. So we should do checkMatrixBounds for the fling. 
![demo_photoview](https://cloud.githubusercontent.com/assets/6004608/26692143/2f38f950-4732-11e7-982c-00a0e8a21d4d.gif)
