### PR TITLE
Ignore layout change event if no bounds has been changed

### DIFF
--- a/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
@@ -325,7 +325,9 @@ public class PhotoViewAttacher implements View.OnTouchListener,
     @Override
     public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
         // Update our base matrix, as the bounds have changed
-        updateBaseMatrix(mImageView.getDrawable());
+        if (left != oldLeft || top != oldTop || right != oldRight || bottom != oldBottom) {
+            updateBaseMatrix(mImageView.getDrawable());
+        }
     }
 
     @Override


### PR DESCRIPTION
`PhotoView#onLayoutChange` may be invoked when no layout has been changed.
For instance, when you call `setSystemUiVisibility` to a decor view, `onLayoutChange` would be invoked though some of those events does not involve a change of bounds.

So, we gotta check if the layout is actually changed or not before calling `updateBaseMatrix`.
Simply ignore if no changes have been occurred.

Thanks.