### PR TITLE
With OnGestureListener public, Xamarin bindings can be created

### DIFF
--- a/photoview/src/main/java/com/github/chrisbanes/photoview/OnGestureListener.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/OnGestureListener.java
@@ -15,7 +15,7 @@
  *******************************************************************************/
 package com.github.chrisbanes.photoview;
 
-interface OnGestureListener {
+public interface OnGestureListener {
 
     void onDrag(float dx, float dy);
 


### PR DESCRIPTION
When trying to create a Xamarin binding for PhotoView, an error occurred because the interface OnGestureListener is not public. From the [Xamarin documentation](https://developer.xamarin.com/guides/android/advanced_topics/binding-a-java-library/troubleshooting-bindings/#Problem_Missing_C_types_in_generated_output.):

> Java allows deriving a public class from non-public class, but this is unsupported in .NET. Since the binding generator does not generate bindings for non-public classes, derived classes such as these cannot be generated correctly. To fix this, either remove the metadata entry for those derived classes using the remove-node in Metadata.xml, or fix the metadata that is making the non-public class public.

Making OnGestureListener public allows Xamarin Bindings to be created and the PhotoView 
to be used in Xamarin\Mono for Android applications.