### PR TITLE
Extend AppCompatImageView instead of ImageView

### DIFF
--- a/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoView.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoView.java
@@ -23,13 +23,13 @@ import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.util.AttributeSet;
 import android.view.GestureDetector;
-import android.widget.ImageView;
+import android.support.v7.widget.AppCompatImageView;
 
 /**
  * A zoomable {@link ImageView}. See {@link PhotoViewAttacher} for most of the details on how the zooming
  * is accomplished
  */
-public class PhotoView extends ImageView {
+public class PhotoView extends AppCompatImageView {
 
     private PhotoViewAttacher attacher;
     private ScaleType pendingScaleType;


### PR DESCRIPTION
Extend PhotoView with AppCompatImageView instead of ImageView, as AppCompatImageView provides some benefits like support for vector drawables.