### PR TITLE
Added AdditionalOnTouchListener

### DIFF
--- a/photoview/src/main/java/com/github/chrisbanes/photoview/AdditionalOnTouchListener.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/AdditionalOnTouchListener.java
@@ -1,0 +1,10 @@
+package com.github.chrisbanes.photoview;
+
+import android.view.MotionEvent;
+import android.view.View;
+
+public interface AdditionalOnTouchListener {
+
+    boolean onTouch (View view, MotionEvent event);
+
+}

--- a/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
@@ -91,6 +91,10 @@ public class PhotoViewAttacher implements View.OnTouchListener,
     private boolean mZoomEnabled = true;
     private ScaleType mScaleType = ScaleType.FIT_CENTER;
 
+
+    //For adding our own onTouchListener
+    private AdditionalOnTouchListener mAdditionalOnTouchListener;
+
     private OnGestureListener onGestureListener = new OnGestureListener() {
         @Override
         public void onDrag(float dx, float dy) {
@@ -332,6 +336,10 @@ public class PhotoViewAttacher implements View.OnTouchListener,
         return mScaleType;
     }
 
+    public void setAdditionalOnTouchListener (AdditionalOnTouchListener listener) {
+        this.mAdditionalOnTouchListener = listener;
+    }
+
     @Override
     public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
         // Update our base matrix, as the bounds have changed
@@ -342,6 +350,15 @@ public class PhotoViewAttacher implements View.OnTouchListener,
 
     @Override
     public boolean onTouch(View v, MotionEvent ev) {
+
+        if (mAdditionalOnTouchListener != null) {
+            if (mAdditionalOnTouchListener.onTouch(v, ev)) { //It consumed
+                return true;
+            } else {
+                //Continue
+            }
+        }
+
         boolean handled = false;
 
         if (mZoomEnabled && Util.hasDrawable((ImageView) v)) {


### PR DESCRIPTION
Since `PhotoViewAttacher` also uses `OnTouchListener`, instead of `PhotoView`overriding `onTouchEvent`, this made user of PhotoView unable to set their own `OnTouchListener` on top of `PhotoView`.

For example, if I want to also be able to start a drag and drop (but not by long press, which is already available as a custom listener) when my drag action has gone outside of the view bound, `PhotoView` has no way to deal with this now.

So I simply added an additional OnTouchListener.  
If user does not add it, it won't affect any of the existing functionality of this library.
If user adds it and returned true, the on-going code in `OnTouch` of `PhotoViewAttacher` will not continue to execute.

See if you agree to add this additional functionality. Thanks!