### PR TITLE
Fix getPointerCount() calls

### DIFF
--- a/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
@@ -181,7 +181,7 @@ public class PhotoViewAttacher implements View.OnTouchListener,
                     }
 
                     if (e1.getPointerCount() > SINGLE_TOUCH
-                            || e1.getPointerCount() > SINGLE_TOUCH) {
+                            || e2.getPointerCount() > SINGLE_TOUCH) {
                         return false;
                     }
 


### PR DESCRIPTION
When I submitted pull request #621 I accidentally replaced `MotionEventCompat.getPointerCount(e2)` with `e1.getPointerCount()` instead of `e2.getPointerCount()`.

Thank you to @rexih for noticing!