### PR TITLE
Added image bounce on scaling down

### DIFF
--- a/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
@@ -137,7 +137,7 @@ public class PhotoViewAttacher implements View.OnTouchListener,
 
         @Override
         public void onScale(float scaleFactor, float focusX, float focusY) {
-            if ((getScale() < mMaxScale || scaleFactor < 1f) && (getScale() > mMinScale || scaleFactor > 1f)) {
+            if (getScale() < mMaxScale || scaleFactor < 1f) {
                 if (mScaleChangeListener != null) {
                     mScaleChangeListener.onScaleChange(scaleFactor, focusX, focusY);
                 }


### PR DESCRIPTION
Removed scaling down restriction in order to let image bounce from scaled down size to normal size. This is how it looks now:
 
![photoviewbounce](https://user-images.githubusercontent.com/7988176/49151105-06008300-f320-11e8-9d32-de63a53b153f.gif)

